### PR TITLE
File Cancel Button Return Null

### DIFF
--- a/lib/screens/channel/components/attachment_modal.dart
+++ b/lib/screens/channel/components/attachment_modal.dart
@@ -53,7 +53,7 @@ class AttachmentModal {
                   title: Text('Cancel'),
                   onTap: () {
                     Navigator.pop(context);
-                    wait.complete(null);
+                    return null;
                   },
                 ),
               ],


### PR DESCRIPTION
Returns error when cancel button is pressed for file upload. (Due to returning wrong response type). I have fixed it by returning the correct return type allowing user to press cancel button for file upload (thus not having any error in the console)