### PR TITLE
Upgrade Sendbird SDK Version to 3.1.9

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
   intl: ^0.17.0
   provider: ^5.0.0
   cached_network_image: ^3.0.0
-  sendbird_sdk: ^3.1.0
+  sendbird_sdk: ^3.1.9
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.0


### PR DESCRIPTION
To insure flutter web to properly work use sendbird_sdk 3.1.9 (which includes support flutter)